### PR TITLE
Sync Coda content to GitBook [automated]

### DIFF
--- a/parallel-partner-initiatives-and-resources/related-initiatives-comparison.md
+++ b/parallel-partner-initiatives-and-resources/related-initiatives-comparison.md
@@ -1,7 +1,7 @@
 # Related Initiatives Comparison
 
 {% hint style="info" %}
-This comparison is auto-generated from our internal database. Last updated: February 2026
+This comparison is auto-generated from our internal database. Last updated: July 2026
 {% endhint %}
 
 ## Highly Related Initiatives
@@ -26,6 +26,7 @@ These initiatives share significant overlap with The Unjournal's mission or are 
 
 | Initiative | Type | Notes |
 |------------|------|-------|
+| ASAPBio | 📄 Open public evaluation initiative or innovative journal |  |
 | [Cascad](https://www.cascad.tech/) | 🔄 replication/reproducibility/robustness | "the first certification agency for scientific code & data" -- a possible source of worthy 'open' work |
 | [Economics e-journal](https://www.degruyterbrill.com/journal/key/econ/html) | 📄 Open public evaluation initiative or innovative journal | At least some detailed public evaluations, although they don’t make these as prominent as Unjournal. Founded 2007, owned by DeGruyter from 2020. |
 | [Kotahi](https://kotahi.community/) | 🔧 Platform/tool: reviewing/rating/endorsing (and publishing) | Connected to Sciety, eLife, etc. Workflow and editorial management platform for open access publishing. |

--- a/readme-1/discussion-team/README.md
+++ b/readme-1/discussion-team/README.md
@@ -1,80 +1,85 @@
 ---
-description: "Auto-generated from Coda. Last synced: 2026-04-13"
+description: Auto-generated from Coda. Last synced: 2026-07-06
 ---
 
 # Our Team
 
-{% hint style="info" %}
-**Visual overviews:** [Team page with photos](https://info.unjournal.org/team.html) · [Interactive org chart](https://info.unjournal.org/org-chart.html) — role descriptions, hover-overs, and member lists.
-{% endhint %}
-
 ## Management Team
 
-- [Alexander Herwix](https://www.researchgate.net/profile/Alexander-Herwix) — Leipzig University, Info. sys.
+- Alexander Herwix — Cologne Institute for Information Systems, Info. sys.
 - [Andrei Potlogea](https://sites.google.com/site/andreipotlogeaupf/)
 - [Anirudh Tagat](https://www.anirudhtagat.com) — Monk Prayogshala, Econ.
-- [Bob Kubinec](https://www.robertkubinec.com/) — University of Virginia
-- David Reinstein, Founder & Co-Director
+- Bob Kubinec — University of South Carolina
 - [Gavin Taylor](https://www.linkedin.com/in/gavin-taylor-9a409453/?originalSubdomain=br) — IGDORE, Neurosci.
 - [Hansika Kapoor](https://www.hansikakapoor.in/) — Monk Prayogshala, Psych.
 - [Ryan Briggs](https://www.ryancbriggs.net/) — University of Guelph, Pol. Sci
-- [Valentin Klotzbücher](https://valentink.quarto.pub/) — University Hospital Basel, GH (also Field Specialist)
+- [Valentin Klotzbücher](https://valentink.quarto.pub/) — University Hospital Basel, Econ., GH
 
 ## Advisory Board
 
-- [Anca Hanea](https://findanexpert.unimelb.edu.au/profile/697859-anca-hanea) — University of Melbourne, RepliCATS
+- [Anca Hanea](https://findanexpert.unimelb.edu.au/profile/697859-anca-hanea) — University of Melbourne,RepliCATS
 - Daniela Cialfi — Econ.
-- [Rosie Bettle](https://uk.linkedin.com/in/rosie-bettle-84a1051b0) — Founders Pledge (also Field Specialist)
-- [Emmanuel Orkoh](https://scholar.google.com/citations?user=hMW0bj4AAAAJ&hl=en) — North-West University, South Africa, Econ.
+- Davit Jintcharadze (former Operations Manager)
+- Demetrius Floudas
+- [Don A. Moore](https://haas.berkeley.edu/faculty/don-moore/)
+- Emmanuel Orkoh — Econ.
 - [Gustav Nilsonne](https://nilsonne.net/) — Karolinska Institutet, Neurosci.
 - [Jake Eaton](https://www.linkedin.com/in/jake-eaton-phd-bb204634/) — Asterisk magazine, Pub. health
-- [Jordan Dworkin](https://jordandworkin.com/) — Open Philanthropy
-- [Kris Gulati](https://sites.google.com/view/kris-gulati/home) — UC Berkeley, Econ.
-- Lorenzo Pacchiardi — Leverhulme Centre for the Future of Intelligence
+- Jordan Dworkin — Open Philanthropy, Biostats.
+- Kris Gulati — Econ.
+- Lorenzo Pacchiardi — Econ.
+- [Michael Harre](https://www.sydney.edu.au/science/about/our-people/academic-staff/michael-harre.html)
 - [Michael Wiebe](https://michaelwiebe.com/) — Econ.
 - [Nicolas Treich](https://scholar.google.fr/citations?user=-S6D7OsAAAAJ&hl=en) — Institut National de la Recherche pour l’Agriculture,l’Alimentation et l’Environnement (INRAe), Econ.
-- [Sarah Anne Reynolds](https://sites.google.com/view/sarah-a-reynolds/home) — World Bank, Econ., GH
-- [Tanya O'Garra](https://sites.google.com/view/tanyaogarra/home) — Imperial College London, Econ.
+- [Paolo Crosetto](https://paolocrosetto.wordpress.com/)
+- [Stuart Buck](https://goodscienceproject.org/)
+- Tanya O'Garra — Econ.
 - [Yannick Dupraz](https://sites.google.com/site/yannickdupraz/)
 
 ## Field Specialists
 
+- [Chisom Nri-Ezedi](https://www.linkedin.com/in/chisom-nri-ezedi-mbbs-md-mph-phd-fwacp-5a1325123)
+- [Elena Briones Alonso   │](https://www.linkedin.com/in/elena-brionesalonso)
 - [Andrew Kao](https://andrew-kao.github.io/) — Harvard University, Econ.
+- Anthony Rowett
+- [Ash Meader](https://faunalytics.org/author/ashleyemeader/) — Faunalytics,Faunalytics
 - [Ben Balmford](https://www.benbalmford.com/) — Exeter, Econ.
 - [Brinda Poojary](https://www.linkedin.com/in/brinda-poojary-phd-ba075458/?originalSubdomain=in) — Humane Society International - India,India Animal Fund
 - [Bryan Weber](https://www.linkedin.com/in/bryan-s-weber/) — CUNY
-- [Chisom Nri-Ezedi](https://www.linkedin.com/in/chisom-nri-ezedi-mbbs-md-mph-phd-fwacp-5a1325123) — Global Public Health
-- [Elena Briones Alonso](https://www.linkedin.com/in/elena-brionesalonso) — Development Economics
-- [Elise Racine](https://www.linkedin.com/in/eliseeracine/) — Global Public Health
 - [Carina Ines Hausladen](https://carinahausladen.github.io/) — EtH Zurich, Econ.
 - [Charlotte Lane](https://www.foodsecurityevidence.com/) — Food Security Evidence Brokerage,3ie
 - [David Manheim](https://scholar.google.com/citations?user=6-M1ZIUAAAAJ&hl=en) — Association for Long Term Existence and Resilience (ALTER),Technion - Israel Institute of Technology, Econ.
-- Eliana Hadjiandreou — Computational Affective and Social Cognition
-- [Emmanuel Orkoh](https://scholar.google.com/citations?user=hMW0bj4AAAAJ&hl=en) — North-West University, South Africa, Econ.
+- [Elena Briones Alonso](https://www.linkedin.com/in/elena-brionesalonso)
+- Emmanuel Orkoh — Econ.
 - [Florian Habermacher](https://habermacher.net/) — Lucerne University,Swiss Institution for International Economics, Econ.
 - [Francesco Ramponi](https://scholar.google.com/citations?user=DdbGN6UAAAAJ&hl=en&oi=ao) — Harvard T.H. Chan School of Public Health, Econ., GH
 - [Gary McDowell](https://www.linkedin.com/in/gary-mcdowell-4551131a/) — IGDORE
 - [Greg Sasso](https://gregsasso.me/) — University of Chicago
 - [Hannah Metzler](https://hannahmetzler.eu/)
+- Jiawei Li
 - [Joel Christoph](https://www.linkedin.com/in/joelchristoph/) — Effective Thesis project, Econ.
 - [Jonah Goldberg](https://www.linkedin.com/in/jonah-s-goldberg/) — Harvard Dept. of Global Health and Population, Econ.
 - [Josh Tasoff](https://scholar.google.com/citations?user=pyjguMoAAAAJ&hl=en) — Claremont Graduate University, Econ.
 - Julian Jamison — Global Priorities Institute,Exeter, Econ.
 - [Kevin J Kuruc](https://sites.google.com/view/kevinkuruc/home) — University of Texas at Austin, Econ.
-- [Kris Gulati](https://sites.google.com/view/kris-gulati/home) — UC Merced, Econ.
+- Kris Gulati — Econ.
 - [Lachlan Deer](https://lachlandeer.github.io/) — Tilburg University
 - [Lee Crawfurd](https://sites.google.com/view/leecrawfurd/home)
-- Lorenzo Pacchiardi — Leverhulme Centre for the Future of Intelligence
-- [Mattie Toma](https://www.mattietoma.com/) — University of Warwick
+- Lorenzo Pacchiardi — Econ.
+- [Mattie Toma](https://www.mattietoma.com/) — University of Warwick, Econ.
 - [Moritz Hennicke](https://hennicke.science/) — University of Bremen
 - Nathan Fiala — University of Connecticut, Econ.
 - [Priya Lall](https://www.linkedin.com/in/priya-lall-64152816/) — University of Oxford
+- Pía Garavaglia
+- Rachel Palm
+- Radhika Rao
 - Rakefet Cohen Ben-Arye
-- [Rosie Bettle](https://uk.linkedin.com/in/rosie-bettle-84a1051b0) — Founders Pledge (also Advisory Board)
-- [Sarah Anne Reynolds](https://sites.google.com/view/sarah-a-reynolds/home) — World Bank, Econ., GH
+- Ramesh Poluru
+- [Rosie Bettle](https://uk.linkedin.com/in/rosie-bettle-84a1051b0?original_referer=https%3A%2F%2Fwww.google.com%2F) — Founders Pledge
+- Sarah Anne Reynolds — UC Berkeley, Econ., GH
 - Sean Brocklebank — Econ.
 - [Tabare Capitan](https://www.tabarecapitan.com) — SLU - Swedish University of Agricultural Sciences, Econ.
-- [Tanya O'Garra](https://sites.google.com/view/tanyaogarra/home) — Imperial College London, Econ.
+- Tanya O'Garra — Econ.
 - [Tristan Williams](https://www.linkedin.com/in/tristan-williams-916119216/) — Center for AI Policy
 - [Valentin Klotzbücher](https://valentink.quarto.pub/) — University Hospital Basel, Econ., GH
 - [Wayne Sandholtz](https://waynesandholtz.com/) — Nova School of Business and Economics, Econ.
@@ -82,7 +87,7 @@ description: "Auto-generated from Coda. Last synced: 2026-04-13"
 
 ## Unjournal Research Affiliates
 
-27 research affiliates contribute to research prioritization, evaluation management, and field expertise.
+56 research affiliates contribute to research prioritization, evaluation management, and field expertise.
 
 ## Evaluator Pool
 
@@ -105,6 +110,6 @@ We maintain relationships with many researchers and initiatives in open science 
 
 </details>
 
-***
+---
 
 *Interested in joining? See [how to get involved](https://globalimpact.gitbook.io/the-unjournal-project-and-communication-space/readme-1/call-for-participants-research) or [get in touch](mailto:contact@unjournal.org).*


### PR DESCRIPTION
Automated sync of team, fields, and initiatives data from Coda.

Updated files:
parallel-partner-initiatives-and-resources/related-initiatives-comparison.md
readme-1/discussion-team/README.md

*Created by GitHub Actions from [coda_org_unjournal](https://github.com/daaronr/coda-unjournal-private)*